### PR TITLE
Update .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,6 @@ phpunit.phar
 # phpunit cache
 .phpunit.result.cache
 
+# Phan
+analysis.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: php
 
-php:
-  - '7.2'
-  - '7.3'
+env:
+  global:
+    - DEFAULT_COMPOSER_FLAGS="--prefer-dist --no-interaction --no-progress --optimize-autoloader"
+    - TASK_STATIC_ANALYSIS=0
+    - TASK_TESTS_COVERAGE=0
+
+matrix:
+  include:
+    - php: '7.2'
+      env:
+        - TASK_TESTS_COVERAGE=1
+    - php: '7.3'
+      env:
+        - TASK_STATIC_ANALYSIS=0 # set to 1 to enable static analysis
 
 # faster builds on new travis setup not using sudo
 sudo: false
@@ -12,15 +23,41 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+  - phpenv config-rm xdebug.ini || echo "xdebug is not installed"
+
 install:
   - travis_retry composer self-update && composer --version
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - travis_retry composer install --prefer-dist --no-interaction
+  - travis_retry composer install $DEFAULT_COMPOSER_FLAGS
+  - |
+    if [ $TASK_STATIC_ANALYSIS == 1 ]; then
+      pecl install ast
+    fi
+
+before_script:
+  - php --version
+  - composer --version
+  # enable code coverage
+  - |
+    if [ $TASK_TESTS_COVERAGE == 1 ]; then
+        PHPUNIT_COVERAGE_FLAG="--coverage-clover=coverage.clover"
+    fi
 
 script:
+  - phpdbg -qrr vendor/bin/phpunit --verbose $PHPUNIT_COVERAGE_FLAG
   - |
-    vendor/bin/phpunit $PHPUNIT_FLAGS --coverage-clover=coverage.clover
+    if [ $TASK_STATIC_ANALYSIS == 1 ]; then
+      composer phan
+    fi
+  - |
+    if [ $TASK_STATIC_ANALYSIS == 1 ]; then
+      cat analysis.txt
+    fi
 
 after_script:
-    - wget -c https://scrutinizer-ci.com/ocular.phar
-    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - |
+    if [ $TASK_TESTS_COVERAGE == 1 ]; then
+      travis_retry wget https://scrutinizer-ci.com/ocular.phar
+      php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - php: '7.3'
       env:
         - TASK_STATIC_ANALYSIS=0 # set to 1 to enable static analysis
+    - php: '7.4snapshot'
 
 # faster builds on new travis setup not using sudo
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": "^7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.2"
+        "phpunit/phpunit": "^8.2",
+        "phan/phan": "^2.2"
     },
     "autoload": {
         "psr-4": {
@@ -32,5 +33,8 @@
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         }
+    },
+    "scripts": {
+        "phan": "phan --progress-bar -o analysis.txt"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
+<phpunit backupGlobals="false"
          colors="true"
          verbose="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
-         failOnWarning="true"
->
+         failOnWarning="true">
     <php>
-        <ini name="error_reporting" value="-1" />
+        <ini name="error_reporting" value="-1"/>
     </php>
 
     <testsuites>
         <testsuite name="Yii _____ tests">
-            <directory>./tests/</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
Run code coverage only on PHP 7.2.
Added configuration for running static analysis on PHP 7.3 (disabled by default).