### PR TITLE
Added PHPUnit tests as a GitHub action

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,37 @@
+name: PHPUnit tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest]
+        php: ['7.2', '7.3', '7.4']
+
+    name: PHP ${{ matrix.php }} on ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Install PHP
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+          extension-csv: curl, mbstring
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader
+      - name: PHP Unit tests
+        run: php ./vendor/bin/phpunit --verbose
+        if: matrix.php != '7.2'
+      - name: PHP Unit tests
+        run: php ./vendor/bin/phpunit --verbose --coverage-clover=coverage.clover
+        if: matrix.php == '7.2'
+      - name: Code coverage
+        run: |
+          wget https://scrutinizer-ci.com/ocular.phar
+          php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+        if: matrix.php == '7.2'
+        continue-on-error: true # if is fork
+

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,7 +19,7 @@ jobs:
         uses: shivammathur/setup-php@master
         with:
           php-version: ${{ matrix.php }}
-          extension-csv: curl, mbstring
+          extension-csv: curl, mbstring, dom
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader
       - name: PHP Unit tests


### PR DESCRIPTION
This action executes PHPUnit tests without travis dependency. It works with default GitHub actions:
https://github.com/simialbi/template/commit/ca01a608d262959eb3fcb5948b76dc9698b0cf2f/checks?check_suite_id=265348254

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    |  〰️ (could replace travis)
| Tests pass?   | ✔️
| Fixed issues  |
